### PR TITLE
Setup continuous deployment to Fly

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,0 +1,15 @@
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Before merging this PR, you'd want to create a token first with `flyctl tokens create deploy -x 999999h` in the Fly project folder, and then save that token as a `FLY_API_TOKEN` in GitHub repository secrets. 

Instructions from https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/